### PR TITLE
Add '--no-duplicate-basename-check' to compilation directive './ios/l…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # we specify a root target for android to prevent all of the targets from spidering out
 ./ios/librncpp.xcodeproj: ./src/lib/librncpp.gyp ./src/third_party/djinni/support-lib/support_lib.gyp ./src/djinni/helloworld.djinni
 	npm run djinni
-	src/third_party/gyp/gyp --depth=. -f xcode -DOS=ios --generator-output ./ios -Isrc/third_party/djinni/common.gypi ./src/lib/librncpp.gyp
+	src/third_party/gyp/gyp --depth=. -f xcode -DOS=ios --generator-output ./ios -Isrc/third_party/djinni/common.gypi ./src/lib/librncpp.gyp --no-duplicate-basename-check
 
 ios: ./ios/librncpp.xcodeproj
 	xcodebuild -project ios/ReactNativeCPP.xcodeproj \


### PR DESCRIPTION
Add '--no-duplicate-basename-check' to compilation directive './ios/librncpp.xcodeproj' in order to avoid the following error : "static library src/lib/librncpp.gyp:librncpp_objc#target has several files with the same basename: ... libtool on Mac cannot handle that."